### PR TITLE
blueprint has been removed from compass 0.13

### DIFF
--- a/bin/gitstats
+++ b/bin/gitstats
@@ -8,6 +8,7 @@ require 'rubygems'
 require 'haml'
 require 'sass'
 require 'compass'
+require 'compass-blueprint'
 require 'gnuplot'
 
 $LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib')))

--- a/gitstats-ruby.gemspec
+++ b/gitstats-ruby.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'haml'
   s.add_dependency 'sass'
   s.add_dependency 'compass'
+  s.add_dependency 'compass-blueprint'
   s.add_dependency 'gnuplot'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
It is now available as compass-blueprint gem. [1]

[1] http://compass-style.org/blog/2012/05/20/removing-blueprint/